### PR TITLE
Make atomicModifyStripe strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work/
+dist-newstyle/

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/8.yaml
+resolver: lts-20.19
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,8 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 587126
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/8.yaml
-    sha256: 93a107557e8691ed5ca17beaee41e68222b142c48868fc8c04a4181fb233477d
-  original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/8.yaml
+    sha256: 42f77c84b34f68c30c2cd0bf8c349f617a0f428264362426290847a6a2019b64
+    size: 649618
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/19.yaml
+  original: lts-20.19

--- a/thread-utils-context/ChangeLog.md
+++ b/thread-utils-context/ChangeLog.md
@@ -1,3 +1,7 @@
 # Changelog for thread-utils-context
 
+## 0.3.0.3
+
+- Fix compilation of purgeDeadThreads on GHC 9.6
+
 ## Unreleased changes

--- a/thread-utils-context/ChangeLog.md
+++ b/thread-utils-context/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for thread-utils-context
 
+## 0.3.0.4 
+
+- Fix compilation on GHC 8.12
+
 ## 0.3.0.3
 
 - Fix compilation of purgeDeadThreads on GHC 9.6

--- a/thread-utils-context/package.yaml
+++ b/thread-utils-context/package.yaml
@@ -1,5 +1,5 @@
 name:                thread-utils-context
-version:             0.3.0.1
+version:             0.3.0.2
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"

--- a/thread-utils-context/package.yaml
+++ b/thread-utils-context/package.yaml
@@ -1,5 +1,5 @@
 name:                thread-utils-context
-version:             0.1.0.0
+version:             0.2.0.0
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"
@@ -25,8 +25,17 @@ dependencies:
 - containers
 - ghc-prim
 
+flags:
+  debug:
+    description: Whether to enable some additional hooks to debug issues
+    default: false
+    manual: true
+
 library:
   source-dirs: src
+  when:
+    - condition: flag(debug)
+      cpp-options: -DDEBUG_HOOKS
 
 tests:
   thread-utils-context-test:
@@ -38,3 +47,5 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - thread-utils-context
+    - hspec
+    - hspec-expectations

--- a/thread-utils-context/package.yaml
+++ b/thread-utils-context/package.yaml
@@ -1,10 +1,10 @@
 name:                thread-utils-context
-version:             0.3.0.2
+version:             0.3.0.3
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"
 maintainer:          "ian@iankduncan.com"
-copyright:           "2021 Ian Duncan"
+copyright:           "2023 Ian Duncan"
 
 extra-source-files:
 - README.md

--- a/thread-utils-context/package.yaml
+++ b/thread-utils-context/package.yaml
@@ -1,5 +1,5 @@
 name:                thread-utils-context
-version:             0.2.0.0
+version:             0.3.0.1
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"

--- a/thread-utils-context/package.yaml
+++ b/thread-utils-context/package.yaml
@@ -1,5 +1,5 @@
 name:                thread-utils-context
-version:             0.3.0.3
+version:             0.3.0.4
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"

--- a/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
+++ b/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
@@ -215,7 +215,7 @@ storedItems tsm = do
 #if MIN_VERSION_base(4,18,0)
 -- | This should generally not be needed, but may be used to remove values prior to GC-triggered finalizers being run from the 'ThreadStorageMap' for threads that have exited.
 purgeDeadThreads :: MonadIO m => ThreadStorageMap a -> m ()
-purgeDeadThreads tsm = do
+purgeDeadThreads tsm = liftIO $ do
   tids <- listThreads
   let threadSet = IS.fromList $ map getThreadId tids
   forM_ [0..(numStripes - 1)] $ \stripe ->

--- a/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
+++ b/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
@@ -218,7 +218,7 @@ storedItems tsm = do
 purgeDeadThreads :: MonadIO m => ThreadStorageMap a -> m ()
 purgeDeadThreads tsm = liftIO $ do
   tids <- listThreads
-  let threadSet = IS.fromList $ map getThreadId tids
+  let threadSet = IS.fromList $ map (fromIntegral . getThreadId) tids
   forM_ [0..(numStripes - 1)] $ \stripe ->
     atomicModifyStripe tsm stripe $ \im -> (I.restrictKeys im threadSet, ())
 #endif

--- a/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
+++ b/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
@@ -71,7 +71,7 @@ import qualified Data.IntMap.Strict as I
 import qualified Data.IntSet as IS
 import Foreign.C.Types
 import Prelude hiding (lookup)
-import Unsafe.Coerce (unsafeCoerce#)
+import GHC.Exts (unsafeCoerce#)
 
 foreign import ccall unsafe "rts_getThreadId" c_getThreadId :: Addr# -> CULLong
 

--- a/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
+++ b/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
@@ -55,7 +55,7 @@ module Control.Concurrent.Thread.Storage
 
 import Control.Concurrent
 import Control.Concurrent.Thread.Finalizers
-import Control.Monad ( when, void )
+import Control.Monad ( when, void, forM_ )
 import Control.Monad.IO.Class
 import Data.Maybe (isNothing, isJust)
 import GHC.Base (Addr#)

--- a/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
+++ b/thread-utils-context/src/Control/Concurrent/Thread/Storage.hs
@@ -98,7 +98,7 @@ atomicModifyStripe (ThreadStorageMap arr#) tid f = IO $ \s -> go s
         let (updatedIntMap, result) = f intMap 
         in case casArray# arr# stripe# intMap updatedIntMap s1 of
              (# s2, outcome, old #) -> case outcome of
-               0# -> (# s2, result #)
+               0# -> updatedIntMap `seq` (# s2, result #)
                1# -> go s2
                _ -> error "Got impossible result in atomicModifyStripe"
           

--- a/thread-utils-context/test/Spec.hs
+++ b/thread-utils-context/test/Spec.hs
@@ -4,22 +4,42 @@ import Control.Concurrent
 import Control.Concurrent.MVar
 import Control.Concurrent.Thread.Storage
 import Control.Monad
+import Data.List hiding (lookup)
+import Test.Hspec
+import Prelude hiding (lookup)
 
 main :: IO ()
-main = do
-  mv <- newEmptyMVar
-  tsm <- newThreadStorageMap
-  replicateM_ 20 $ do
-    forkIO $ do
-      myThreadId >>= print
-      attach tsm ()
-      readMVar mv
-  threadDelay 2_000_000
-  print =<< storedItems tsm
-  putMVar mv ()
-  threadDelay 2_000_000
-  performGC
-  print =<< storedItems tsm
+main = hspec $ do
 
-  
-
+  describe "cleanup" $ do
+    it "works" $ do
+      mv <- newEmptyMVar
+      tsm <- newThreadStorageMap
+      replicateM_ 100000 $ do
+        forkIO $ do
+          attach tsm ()
+          readMVar mv
+      threadDelay 10_000_000
+      putMVar mv ()
+      threadDelay 10_000_000
+      performGC
+      threadDelay 10_000_000
+      thingsStillInStorage <- storedItems tsm
+      sort thingsStillInStorage `shouldBe` []
+    it "doesn't happen while a thread is still alive" $ do
+      tsm <- newThreadStorageMap
+      mv <- newEmptyMVar
+      resultVar <- newEmptyMVar
+      forkIO $ do
+        attach tsm ()
+        readMVar mv
+        putMVar resultVar =<< lookup tsm
+      threadDelay 5_000_000
+      performGC
+      putMVar mv ()
+      result <- readMVar resultVar
+      result `shouldBe` Just ()
+      performGC
+      threadDelay 5_000_000
+      items <- storedItems tsm
+      items `shouldBe` []

--- a/thread-utils-context/thread-utils-context.cabal
+++ b/thread-utils-context/thread-utils-context.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-context
-version:        0.2.0.0
+version:        0.3.0.1
 synopsis:       Garbage-collected thread local storage
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-utils-context#readme>
 category:       Concurrency

--- a/thread-utils-context/thread-utils-context.cabal
+++ b/thread-utils-context/thread-utils-context.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-context
-version:        0.3.0.3
+version:        0.3.0.4
 synopsis:       Garbage-collected thread local storage
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-utils-context#readme>
 category:       Concurrency

--- a/thread-utils-context/thread-utils-context.cabal
+++ b/thread-utils-context/thread-utils-context.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-context
-version:        0.3.0.1
+version:        0.3.0.2
 synopsis:       Garbage-collected thread local storage
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-utils-context#readme>
 category:       Concurrency

--- a/thread-utils-context/thread-utils-context.cabal
+++ b/thread-utils-context/thread-utils-context.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-context
-version:        0.3.0.2
+version:        0.3.0.3
 synopsis:       Garbage-collected thread local storage
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-utils-context#readme>
 category:       Concurrency
@@ -13,7 +13,7 @@ homepage:       https://github.com/iand675/thread-utils#readme
 bug-reports:    https://github.com/iand675/thread-utils/issues
 author:         Ian Duncan
 maintainer:     ian@iankduncan.com
-copyright:      2021 Ian Duncan
+copyright:      2023 Ian Duncan
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/thread-utils-context/thread-utils-context.cabal
+++ b/thread-utils-context/thread-utils-context.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-context
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       Garbage-collected thread local storage
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-utils-context#readme>
 category:       Concurrency
@@ -25,6 +25,11 @@ source-repository head
   type: git
   location: https://github.com/iand675/thread-utils
 
+flag debug
+  description: Whether to enable some additional hooks to debug issues
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Control.Concurrent.Thread.Storage
@@ -38,6 +43,8 @@ library
     , ghc-prim
     , thread-utils-finalizers
   default-language: Haskell2010
+  if flag(debug)
+    cpp-options: -DDEBUG_HOOKS
 
 test-suite thread-utils-context-test
   type: exitcode-stdio-1.0
@@ -51,6 +58,8 @@ test-suite thread-utils-context-test
       base >=4.7 && <5
     , containers
     , ghc-prim
+    , hspec
+    , hspec-expectations
     , thread-utils-context
     , thread-utils-finalizers
   default-language: Haskell2010

--- a/thread-utils-finalizers/package.yaml
+++ b/thread-utils-finalizers/package.yaml
@@ -1,5 +1,5 @@
 name:                thread-utils-finalizers
-version:             0.1.0.0
+version:             0.1.1.0
 github:              "iand675/thread-utils"
 license:             BSD3
 author:              "Ian Duncan"

--- a/thread-utils-finalizers/src/Control/Concurrent/Thread/Finalizers.hs
+++ b/thread-utils-finalizers/src/Control/Concurrent/Thread/Finalizers.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
-module Control.Concurrent.Thread.Finalizers where
+module Control.Concurrent.Thread.Finalizers
+  ( mkWeakThreadIdWithFinalizer
+  , addThreadFinalizer
+  , finalizeThread
+  ) where
 import Control.Concurrent
 import Control.Exception
 import Control.Monad ( void )
 import GHC.IO (IO(..))
 import GHC.Prim ( mkWeak# )
-import GHC.Weak ( Weak(..) )
+import GHC.Weak ( Weak(..), finalize )
 import GHC.Conc.Sync ( ThreadId(..) )
 
 -- | A variant of 'Control.Concurrent.mkWeakThreadId' that supports
@@ -40,3 +44,11 @@ mkWeakThreadIdWithFinalizer t@(ThreadId t#) (IO finalizer) = IO $ \s ->
 -}
 addThreadFinalizer :: ThreadId -> IO () -> IO ()
 addThreadFinalizer tid m = void $ mkWeakThreadIdWithFinalizer tid m
+
+{-|
+  Run a thread's finalizers. This is just a convenience alias for 'System.Mem.Weak.finalize'.
+
+  The thread can still be used afterwards, it will simply not run the associated finalizers again.
+-}
+finalizeThread :: Weak ThreadId -> IO ()
+finalizeThread = finalize

--- a/thread-utils-finalizers/thread-utils-finalizers.cabal
+++ b/thread-utils-finalizers/thread-utils-finalizers.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           thread-utils-finalizers
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Perform finalization for threads.
 description:    Please see the README on GitHub at <https://github.com/iand675/thread-finalizers#readme>
 category:       Concurrency


### PR DESCRIPTION
Previously we could end up with thunks in our mutable variable.
Note that we force the value after we've done the CAS swap, so this shouldn't lead to more retries.